### PR TITLE
Fixing the linking errors for tests when default modules are not built

### DIFF
--- a/itk-module.cmake
+++ b/itk-module.cmake
@@ -5,11 +5,8 @@ convert to and from regular itk::Image.")
 
 itk_module(RLEImage
   DEPENDS
-    ITKCommon
     ITKImageGrid
   TEST_DEPENDS
-    ITKCommon
-    ITKIOImageBase
     ITKTestKernel
   EXCLUDE_FROM_DEFAULT
   DESCRIPTION

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,7 +17,7 @@ ADD_EXECUTABLE(iteratorTests
     itkImageRegionIteratorTest.cxx
     itkImageScanlineIteratorTest1.cxx
     iteratorTests.cxx)
-TARGET_LINK_LIBRARIES(iteratorTests ${ITK_LIBRARIES})
+TARGET_LINK_LIBRARIES(iteratorTests "${RLEImage-Test_LIBRARIES}")
 itk_add_test( NAME iteratorTests COMMAND iteratorTests)
 
 function(ReadWriteTest ImageName Ext)


### PR DESCRIPTION
This should prevent failures of automatic build tests on dashboards