### PR TITLE
Suppressing KWStyle's bug

### DIFF
--- a/ITKKWStyleOverwrite.txt
+++ b/ITKKWStyleOverwrite.txt
@@ -1,0 +1,2 @@
+itkRLEImage.h InternalVariables Disable
+test/.*\.cxx Namespace Disable


### PR DESCRIPTION
~/itkRLEImage/include/itkRLEImage.h:165: error: Internal variable
(>::SetRequestedRegion) doesn't match regular expression (m_[A-Z])