### PR TITLE
ENH: Rename tests to all contain the name of the remote module

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -21,11 +21,11 @@ ADD_EXECUTABLE(iteratorTests
     itkImageScanlineIteratorTest1.cxx
     iteratorTests.cxx)
 TARGET_LINK_LIBRARIES(iteratorTests "${RLEImage-Test_LIBRARIES}")
-itk_add_test( NAME iteratorTests COMMAND iteratorTests)
+itk_add_test( NAME RLEImageiteratorTests COMMAND iteratorTests)
 
 function(ReadWriteTest ImageName Ext)
   set(outImage "${ITK_TEST_OUTPUT_DIR}/${ImageName}.${Ext}")
-  itk_add_test( NAME ${ImageName}
+  itk_add_test( NAME RLEImage${ImageName}
     COMMAND RLEImageTestDriver
     --compare DATA{Input/${ImageName}.${Ext}} ${outImage}
     itkRLEImageTest


### PR DESCRIPTION
All test names now start with the name of the module, RLEImage, which makes
it easier to test the module. One can run the test with a command similar to:

ctest -R RLEImage