### PR TITLE
COMP: Move ITK_DISALLOW_COPY_AND_ASSIGN calls to public section.

### DIFF
--- a/include/itkRLEImage.h
+++ b/include/itkRLEImage.h
@@ -53,6 +53,8 @@ class RLEImage:
   public itk::ImageBase< VImageDimension >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(RLEImage);
+
   /** Standard class type alias */
   using Self = RLEImage;
   using Superclass = itk::ImageBase< VImageDimension >;
@@ -305,10 +307,6 @@ protected:
 
 private:
   bool m_OnTheFlyCleanup; // should same-valued segments be merged on the fly
-
-  RLEImage( const Self & ); // purposely not implemented
-  void
-  operator=( const Self & ); // purposely not implemented
 
   /** Memory for the current buffer. */
   mutable typename BufferType::Pointer m_Buffer;

--- a/include/itkRLERegionOfInterestImageFilter.h
+++ b/include/itkRLERegionOfInterestImageFilter.h
@@ -51,6 +51,8 @@ class RegionOfInterestImageFilter< RLEImage< TPixel, VImageDimension, CounterTyp
     RLEImage< TPixel, VImageDimension, CounterType > >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(RegionOfInterestImageFilter);
+
   /** Standard class type alias. */
   using Self = RegionOfInterestImageFilter;
   using RLEImageType = RLEImage< TPixel, VImageDimension, CounterType >;
@@ -127,10 +129,6 @@ protected:
   ThreadedGenerateData( const RegionType& outputRegionForThread, ThreadIdType threadId ) override;
 
 private:
-  RegionOfInterestImageFilter( const Self & ); // purposely not implemented
-  void
-  operator=( const Self & ); // purposely not implemented
-
   RegionType m_RegionOfInterest;
 };
 
@@ -247,6 +245,8 @@ class RegionOfInterestImageFilter< Image< TPixel, VImageDimension >,
     RLEImage< TPixel, VImageDimension, CounterType > >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(RegionOfInterestImageFilter);
+
   /** Standard class type alias. */
   using RLEImageType = RLEImage< TPixel, VImageDimension, CounterType >;
 
@@ -324,10 +324,6 @@ protected:
   ThreadedGenerateData( const RegionType& outputRegionForThread, ThreadIdType threadId ) override;
 
 private:
-  RegionOfInterestImageFilter( const Self & ); // purposely not implemented
-  void
-  operator=( const Self & ); // purposely not implemented
-
   RegionType m_RegionOfInterest;
 };
 
@@ -338,6 +334,8 @@ class RegionOfInterestImageFilter< RLEImage< TPixel, VImageDimension, CounterTyp
     Image< TPixel, VImageDimension > >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(RegionOfInterestImageFilter);
+
   /** Standard class type alias. */
   using RLEImageType = RLEImage< TPixel, VImageDimension, CounterType >;
 
@@ -415,10 +413,6 @@ protected:
   ThreadedGenerateData( const RegionType& outputRegionForThread, ThreadIdType threadId ) override;
 
 private:
-  RegionOfInterestImageFilter( const Self & ); // purposely not implemented
-  void
-  operator=( const Self & ); // purposely not implemented
-
   RegionType m_RegionOfInterest;
 };
 } // end namespace itk


### PR DESCRIPTION
Move `ITK_DISALLOW_COPY_AND_ASSIGN` calls to public section following
the discussion in
https://discourse.itk.org/t/noncopyable

If legacy (pre-macro) copy and assing methods existed, subsitute them
for the `ITK_DISALLOW_COPY_AND_ASSIGN` macro.