### PR TITLE
ENH: Prefer boolean macro call to initialize dynamic multi-threading ivar.

### DIFF
--- a/include/itkRLERegionOfInterestImageFilter.h
+++ b/include/itkRLERegionOfInterestImageFilter.h
@@ -95,7 +95,7 @@ public:
 
 protected:
   RegionOfInterestImageFilter()
-    { m_DynamicMultiThreading = true; }
+    { this->DynamicMultiThreadingOn(); }
   ~RegionOfInterestImageFilter() override {}
   void
   PrintSelf( std::ostream& os, Indent indent ) const override;
@@ -184,7 +184,7 @@ public:
 
 protected:
   RegionOfInterestImageFilter()
-    { m_DynamicMultiThreading = true; }
+    { this->DynamicMultiThreadingOn(); }
   ~RegionOfInterestImageFilter() override {}
   void
   PrintSelf( std::ostream& os, Indent indent ) const override;
@@ -292,7 +292,7 @@ public:
 
 protected:
   RegionOfInterestImageFilter()
-    { m_DynamicMultiThreading = true; }
+    { this->DynamicMultiThreadingOn(); }
   ~RegionOfInterestImageFilter() override {}
   void
   PrintSelf( std::ostream& os, Indent indent ) const override;
@@ -382,7 +382,7 @@ public:
 
 protected:
   RegionOfInterestImageFilter()
-    { m_DynamicMultiThreading = true; }
+    { this->DynamicMultiThreadingOn(); }
   ~RegionOfInterestImageFilter() override {}
   void
   PrintSelf( std::ostream& os, Indent indent ) const override;


### PR DESCRIPTION
Prefer the boolean macro function call to initialize the dynamic
multi-threading ivar for the reasons stated here:
http://review.source.kitware.com/#/c/23434/