### PR TITLE
DOC: Improve the `itk-module.cmake` documentation,

### DIFF
--- a/itk-module.cmake
+++ b/itk-module.cmake
@@ -1,8 +1,14 @@
-set(DOCUMENTATION "The module provides run-length encoded storage for
-image content, iterators for efficient reading and writing, and a
-specialization of region of interest filter which can also be used to
-convert to and from regular itk::Image.")
+# the top-level README is used for describing this module, just
+# re-used it for documentation here
+get_filename_component(MY_CURENT_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+file(READ "${MY_CURENT_DIR}/README.rst" DOCUMENTATION)
 
+# itk_module() defines the module dependencies in RLEImage
+# The testing module in RLEImage depends on ITKTestKernel
+# By convention those modules outside of ITK are not prefixed with
+# ITK
+
+# define the dependencies of the include module and the tests
 itk_module(RLEImage
   DEPENDS
     ITKImageGrid


### PR DESCRIPTION
Improve the `itk-module.cmake` file documentation:
- Re-use the `README.rst` documentation to increase consistency.
- Add comments.