### PR TITLE
COMP: Change enum to new enum class definitions

### DIFF
--- a/test/itkRLEImageTest.cxx
+++ b/test/itkRLEImageTest.cxx
@@ -194,7 +194,7 @@ int itkRLEImageTest( int argc, char* argv[] )
 
   using ScalarPixelType = itk::ImageIOBase::IOComponentType;
   itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(
-    inputImageFileName, itk::ImageIOFactory::ReadMode);
+    inputImageFileName, itk::ImageIOFactory::FileModeType::ReadMode);
   if (!imageIO)
     {
     std::cerr << "Could not CreateImageIO for: " << inputImageFileName << std::endl;


### PR DESCRIPTION
When ITK is configured with the following:

- ITK_LEGACY_REMOVE = ON

- ITK_FUTURE_LEGACY_REMOVE = ON

- ITK_LEGACY_SILENT = OFF

- Module_RLEImage = ON

Build errors occur with references to older 'C' style enums. The following changes incorporate the new enum class: FileModeType and resolves such errors.

Co-Authored-By: Hans Johnson hans-johnson@uiowa.edu