### PR TITLE
COMP: Use and move ITK_DISALLOW_COPY_AND_ASSIGN call to public section

### DIFF
--- a/include/itkRLERegionOfInterestImageFilter.h
+++ b/include/itkRLERegionOfInterestImageFilter.h
@@ -142,6 +142,8 @@ class RegionOfInterestImageFilter<RLEImage<TPixelIn, VImageDimension, CounterTyp
                               RLEImage<TPixelOut, VImageDimension, CounterTypeOut>>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN( RegionOfInterestImageFilter );
+
   /** Standard class type alias. */
   using Self = RegionOfInterestImageFilter;
   using RLEImageTypeIn = RLEImage<TPixelIn, VImageDimension, CounterTypeIn>;
@@ -218,9 +220,6 @@ protected:
   DynamicThreadedGenerateData(const RegionType & outputRegionForThread) override;
 
 private:
-  RegionOfInterestImageFilter(const Self &) = delete; // purposely not implemented
-  void
-  operator=(const Self &) = delete; // purposely not implemented
 
   RegionType m_RegionOfInterest;
 };


### PR DESCRIPTION
Use the `ITK_DISALLOW_COPY_AND_ASSIGN` macro to enhance consistency across
the the toolkit when disallowing the copy constructor and the assign
operator.

Move the `ITK_DISALLOW_COPY_AND_ASSIGN` calls to public section following
the discussion in
https://discourse.itk.org/t/itk-disallow-copy-and-assign/648