### PR TITLE
STYLE: Rename ITK_DISALLOW_COPY_AND_ASSIGN to ITK_DISALLOW_COPY_A…

### DIFF
--- a/include/itkRLEImage.h
+++ b/include/itkRLEImage.h
@@ -52,7 +52,7 @@ template <typename TPixel, unsigned int VImageDimension = 3, typename CounterTyp
 class RLEImage : public itk::ImageBase<VImageDimension>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(RLEImage);
+  ITK_DISALLOW_COPY_AND_MOVE(RLEImage);
 
   /** Standard class type alias */
   using Self = RLEImage;

--- a/include/itkRLERegionOfInterestImageFilter.h
+++ b/include/itkRLERegionOfInterestImageFilter.h
@@ -51,7 +51,7 @@ class RegionOfInterestImageFilter<RLEImage<TPixel, VImageDimension, CounterType>
                               RLEImage<TPixel, VImageDimension, CounterType>>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(RegionOfInterestImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(RegionOfInterestImageFilter);
 
   /** Standard class type alias. */
   using Self = RegionOfInterestImageFilter;
@@ -142,7 +142,7 @@ class RegionOfInterestImageFilter<RLEImage<TPixelIn, VImageDimension, CounterTyp
                               RLEImage<TPixelOut, VImageDimension, CounterTypeOut>>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN( RegionOfInterestImageFilter );
+  ITK_DISALLOW_COPY_AND_MOVE( RegionOfInterestImageFilter );
 
   /** Standard class type alias. */
   using Self = RegionOfInterestImageFilter;
@@ -246,7 +246,7 @@ class RegionOfInterestImageFilter<Image<TPixel, VImageDimension>, RLEImage<TPixe
   : public ImageToImageFilter<Image<TPixel, VImageDimension>, RLEImage<TPixel, VImageDimension, CounterType>>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(RegionOfInterestImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(RegionOfInterestImageFilter);
 
   /** Standard class type alias. */
   using RLEImageType = RLEImage<TPixel, VImageDimension, CounterType>;
@@ -332,7 +332,7 @@ class RegionOfInterestImageFilter<RLEImage<TPixel, VImageDimension, CounterType>
   : public ImageToImageFilter<RLEImage<TPixel, VImageDimension, CounterType>, Image<TPixel, VImageDimension>>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(RegionOfInterestImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(RegionOfInterestImageFilter);
 
   /** Standard class type alias. */
   using RLEImageType = RLEImage<TPixel, VImageDimension, CounterType>;


### PR DESCRIPTION
This PR fixes changes made in [#2053](https://github.com/InsightSoftwareConsortium/ITK/pull/2053/commits/4eac1a0cfb456fad1e3894173a41d7c7de49b08f). Essentially, `ITK_DISALLOW_COPY_AND_ASSIGN` has been changed to `ITK_DISALLOW_COPY_AND_MOVE` to more accurately convey the actions taking place. `ITK_DISALLOW_COPY_AND_ASSIGN` will **only** be used if `ITK_FUTURE_LEGACY_REMOVE=OFF`.

**NOTE:** These changes will cause the GitHub Actions to break, because they currently build `ITK v5.1.0`. The errors persist with `v5.1.1` as well (will update to newest version in separate PR). When tested locally against `master`, I get all tests to pass. The case is the same for the remaining 39 remote modules.