### PR TITLE
remove recursive header includes

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -13,17 +13,17 @@ jobs:
           - os: ubuntu-18.04
             c-compiler: "gcc"
             cxx-compiler: "g++"
-            itk-git-tag: "abd38d5a0040b9a8fbb0ad3127089dbb72a93342"
+            itk-git-tag: "a89145bccda6a36f42cfdd45d3a6b27234ff54fe"
             cmake-build-type: "MinSizeRel"
           - os: windows-2019
             c-compiler: "cl.exe"
             cxx-compiler: "cl.exe"
-            itk-git-tag: "abd38d5a0040b9a8fbb0ad3127089dbb72a93342"
+            itk-git-tag: "a89145bccda6a36f42cfdd45d3a6b27234ff54fe"
             cmake-build-type: "Release"
           - os: macos-10.15
             c-compiler: "clang"
             cxx-compiler: "clang++"
-            itk-git-tag: "abd38d5a0040b9a8fbb0ad3127089dbb72a93342"
+            itk-git-tag: "a89145bccda6a36f42cfdd45d3a6b27234ff54fe"
             cmake-build-type: "MinSizeRel"
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,28 +1,48 @@
-# Compiled Object files
-*.slo
-*.lo
-*.o
-*.obj
+# Do not add ExternalData module staging files
+.ExternalData*
 
-# Precompiled Headers
-*.gch
-*.pch
+# back-up files
+*~
+*.bak
+# vim swp files
+*.swp
+## Ignore files that are used for auto_completion with clang
+*.clang_complete
+## YouCompleteMe vim plugin configuration file
+.ycm_extra_conf.py
 
-# Compiled Dynamic libraries
-*.so
-*.dylib
-*.dll
 
-# Fortran module files
-*.mod
+# KWStyle hook output
+*.kws
 
-# Compiled Static libraries
-*.lai
-*.la
-*.a
-*.lib
+# compiled python files
+*.pyc
 
-# Executables
-*.exe
-*.out
-*.app
+# Binary directory ignore patterns
+BUILD*/
+build*/
+
+# qtcreator
+CMakeLists.txt.user*
+
+# kdevelop
+*.kdev*
+.kdev*
+
+# back-up files when conflicts occur
+*.orig
+
+# Clion editor internal project information
+.idea
+
+# Visual Studio
+.vs
+
+# Mac System File
+.DS_Store
+
+# Ignore testing temporary files
+Testing/Temporary/
+
+# CMake user presets
+CMakeUserPresets.json

--- a/include/itkRLEImage.hxx
+++ b/include/itkRLEImage.hxx
@@ -19,10 +19,8 @@
 #define itkRLEImage_hxx
 
 #include "itkImageRegionIterator.h" // for underlying buffer
-#include "itkRLEImage.h"
 
 // include all specializations of iterators and filters
-// so only #include <itkRLEImage.h> is needed in user code
 #include "itkRLEImageRegionIterator.h"
 #include "itkRLEImageScanlineIterator.h"
 #include "itkRLERegionOfInterestImageFilter.h"

--- a/include/itkRLERegionOfInterestImageFilter.hxx
+++ b/include/itkRLERegionOfInterestImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkRLERegionOfInterestImageFilter_hxx
 #define itkRLERegionOfInterestImageFilter_hxx
 
-#include "itkRLERegionOfInterestImageFilter.h"
 
 #include "itkImage.h"
 #include "itkImageAlgorithm.h"


### PR DESCRIPTION
COMP: Modules need updated version of ITK

Removal of .h includes from same named .hxx files
requires removal of outdated rule that is no longer
relevant.

This PR will update the version of ITK that is
used for the remove modules."



BRANCH_NAME=update-reference-itk-version
for remdir_script in *.remote.cmake; do
   
  remdir="${remdir_script//*.remote.cmake/}"
  if [ ! -d "${remdir}" ] ;then
    echo "Missing directory ${remdir}"
    continue
  fi
  pushd "${remdir}" || exit
  echo "=============== $(pwd) ========="
  git checkout master
  git fetch origin
  git rebase origin/master
  git checkout -b ${BRANCH_NAME}
  sed 's/itk-git-tag : .*/itk-git-tag: "a89145bccda6a36f42cfdd45d3a6b27234ff54fe"/g' $( fgrep -Rl "itk-git-tag:" |fgrep yml )

  git status
  diff_line_no=$(git diff |wc -l )
  if [ "${diff_line_no}" -ne 0 ]; then
    git add -p
    git commit -F /tmp/update_itk_msg

    gh pr create -a "@me" -F /tmp/update_itk_msg
  else
    echo "Skipping changes $(pwd)"
  fi
  git fetch
  git rebase origin/master 
  git push origin -f ${BRANCH_NAME}:${BRANCH_NAME}

  popd || exit
done
