### PR TITLE
COMP: Remove Python CI workflow

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -6,7 +6,3 @@ jobs:
   cxx-build-workflow:
     uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@e885a99c2e34497c4c5c0c1428a269fb0aae7902
 
-  python-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@e885a99c2e34497c4c5c0c1428a269fb0aae7902
-    secrets:
-      pypi_password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
Removing Python CI workflow as Python packages are unwanted for ITKRLEImage. Results in faster GitHub Actions results for PRs.

Motivated by discussion in
https://github.com/KitwareMedical/ITKRLEImage/pull/58#issuecomment-1527837474