### PR TITLE
ENH: Enable building shared libraries

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -4,5 +4,5 @@ on: [push,pull_request]
 
 jobs:
   cxx-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@e885a99c2e34497c4c5c0c1428a269fb0aae7902
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@3f63de316255a285b0cac4c819d3d45649738999
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,12 @@
 cmake_minimum_required(VERSION 3.16.3)
 project(RLEImage)
 
+if(POLICY CMP0135)
+  cmake_policy(SET CMP0135 NEW)
+endif()
+
 if(NOT ITK_SOURCE_DIR)
-  find_package(ITK 5.3 REQUIRED)
+  find_package(ITK REQUIRED)
   list(APPEND CMAKE_MODULE_PATH ${ITK_CMAKE_DIR})
   include(ITKModuleExternal)
 else()

--- a/itk-module.cmake
+++ b/itk-module.cmake
@@ -10,6 +10,7 @@ file(READ "${MY_CURENT_DIR}/README.rst" DOCUMENTATION)
 
 # define the dependencies of the include module and the tests
 itk_module(RLEImage
+  ENABLE_SHARED
   DEPENDS
     ITKImageGrid
   TEST_DEPENDS

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,6 @@ setup(
     keywords='ITK InsightToolkit Run-length-encoding',
     url=r'https://github.com/KitwareMedical/ITKRLEImage',
     install_requires=[
-        r'itk>=5.3.0'
+        r'itk>=5.4rc2'
     ]
     )


### PR DESCRIPTION
ITK now uses an ENABLE_SHARED flag in itk-module.cmake to explicitly enable building as shared module.