### PR TITLE
COMP: Uninitialized in GetNumberOfComponentsPerPixel

### DIFF
--- a/include/itkRLEImage.h
+++ b/include/itkRLEImage.h
@@ -209,9 +209,7 @@ public:
   {
     // use the GetLength() method which works with variable length arrays,
     // to make it work with as much pixel types as possible
-    PixelType p;
-
-    return itk::NumericTraits<PixelType>::GetLength(p);
+    return itk::NumericTraits<PixelType>::GetLength({});
   }
 
   /** Typedef for the internally used buffer. */


### PR DESCRIPTION
Addresses:

```
In file included from
/Users/matt.mccormick/src/ITK/Modules/External/ITKRLEImage/test/itkRLEImageTest.cxx:19:
/Users/matt.mccormick/src/ITK/Modules/External/ITKRLEImage/include/itkRLEImage.h:214:53:
warning: variable 'p' is uninitialized when passed as a const reference
argument here [-Wuninitialized-const-reference]
    return itk::NumericTraits<PixelType>::GetLength(p);
```

on macOS clang.