### PR TITLE
Scanline iterator RLEImage macOS

### DIFF
--- a/include/itkRLEImageScanlineConstIterator.h
+++ b/include/itkRLEImageScanlineConstIterator.h
@@ -178,6 +178,18 @@ public:
     return *this;
   }
 };
+
+// Deduction guide for class template argument deduction (CTAD).
+template <typename TPixel, unsigned int VImageDimension, typename CounterType>
+ImageScanlineConstIterator(SmartPointer<const RLEImage<TPixel, VImageDimension, CounterType>>,
+                           const typename RLEImage<TPixel, VImageDimension, CounterType>::RegionType &)
+  ->ImageScanlineConstIterator<RLEImage<TPixel, VImageDimension, CounterType>>;
+
+template <typename TPixel, unsigned int VImageDimension, typename CounterType>
+ImageScanlineConstIterator(const RLEImage<TPixel, VImageDimension, CounterType> *,
+                           const typename RLEImage<TPixel, VImageDimension, CounterType>::RegionType &)
+  ->ImageScanlineConstIterator<RLEImage<TPixel, VImageDimension, CounterType>>;
+
 } // end namespace itk
 
 #endif // itkRLEImageScanlineConstIterator_h

--- a/include/itkRLEImageScanlineIterator.h
+++ b/include/itkRLEImageScanlineIterator.h
@@ -102,6 +102,13 @@ protected:
     return *this;
   }
 };
+
+// Deduction guide for class template argument deduction (CTAD).
+template <typename TPixel, unsigned int VImageDimension, typename CounterType>
+ImageScanlineIterator(SmartPointer<RLEImage<TPixel, VImageDimension, CounterType>>,
+                      const typename RLEImage<TPixel, VImageDimension, CounterType>::RegionType &)
+  ->ImageScanlineIterator<RLEImage<TPixel, VImageDimension, CounterType>>;
+
 } // end namespace itk
 
 #endif // itkRLEImageScanlineIterator_h


### PR DESCRIPTION
This addresses
https://github.com/InsightSoftwareConsortium/ITK/issues/4537

In addition to SmartPointer arguments, we need a raw const pointer version.

Suggested-by: Niels Dekker <N.Dekker@lumc.nl>